### PR TITLE
Added the directed network case

### DIFF
--- a/backbone.py
+++ b/backbone.py
@@ -32,7 +32,7 @@ def disparity_filter(G, weight='weight'):
             
             k_in = G.in_degree(u)
             if k_in > 1:
-                sum_w_in = sum(G[v][u]['weight'] for v in G.predecessors(u))
+                sum_w_in = sum(G[v][u][weight] for v in G.predecessors(u))
                 for v in G.predecessors(u):
                     w = G[v][u][weight]
                     p_ij_in = float(w)/sum_w_in

--- a/backbone.py
+++ b/backbone.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy import integrate
 
 
-def disparity_filter(G):
+def disparity_filter(G, weight='weight'):
     ''' Compute significance scores (alpha) for weighted edges in G as defined in Serrano et al. 2009
         Args
             G: Weighted NetworkX graph
@@ -16,17 +16,42 @@ def disparity_filter(G):
         References
             M. A. Serrano et al. (2009) Extracting the Multiscale backbone of complex weighted networks. PNAS, 106:16, pp. 6483-6488.
     '''
-    B = nx.Graph()
-    for u in G:
-        k = len(G[u])
-        if k > 1:
-            sum_w = sum(G[u][v]['weight'] for v in G[u])
-            for v in G[u]:
-                w = G[u][v]['weight']
-                p_ij = float(w)/sum_w
-                alpha_ij = 1 - (k-1) * integrate.quad(lambda x: (1-x)**(k-2), 0, p_ij)[0]
-                B.add_edge(u, v, weight=w, alpha=float('%.4f' % alpha_ij))
-    return B
+    
+    if nx.is_directed(G): #directed case    
+        N = nx.DiGraph()
+        for u in G:
+            
+            k_out = G.out_degree(u)
+            if k_out > 1:
+                sum_w_out = sum(G[u][v][weight] for v in G.successors(u))
+                for v in G.successors(u):
+                    w = G[u][v][weight]
+                    p_ij_out = float(w)/sum_w_out
+                    alpha_ij_out = 1 - (k_out-1) * integrate.quad(lambda x: (1-x)**(k_out-2), 0, p_ij_out)[0]
+                    N.add_edge(u, v, weight = w, alpha_out=float('%.4f' % alpha_ij_out))
+            
+            k_in = G.in_degree(u)
+            if k_in > 1:
+                sum_w_in = sum(G[v][u]['weight'] for v in G.predecessors(u))
+                for v in G.predecessors(u):
+                    w = G[v][u][weight]
+                    p_ij_in = float(w)/sum_w_in
+                    alpha_ij_in = 1 - (k_in-1) * integrate.quad(lambda x: (1-x)**(k_in-2), 0, p_ij_in)[0]
+                    N.add_edge(v, u, weight = w, alpha_in=float('%.4f' % alpha_ij_in))
+        return N
+    
+    else: #undirected case
+        B = nx.Graph()
+        for u in G:
+            k = len(G[u])
+            if k > 1:
+                sum_w = sum(G[u][v][weight] for v in G[u])
+                for v in G[u]:
+                    w = G[u][v][weight]
+                    p_ij = float(w)/sum_w
+                    alpha_ij = 1 - (k-1) * integrate.quad(lambda x: (1-x)**(k-2), 0, p_ij)[0]
+                    B.add_edge(u, v, weight = w, alpha=float('%.4f' % alpha_ij))
+        return B
                 
             
 if __name__ == '__main__':


### PR DESCRIPTION
I've added the directed case, the disparity filter works now for nx.Graph and nx.DiGraph. The algorithm is the same of the undirected case, but the edges of the resulting DiGraph have the new alhpa_in and alpha_out attributes.

The disparity function for directed networks is defined in the supporting information of the original paper:
http://www.pnas.org/content/106/16/6483.abstract?tab=ds
